### PR TITLE
Let consumer handle persistence

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@outlinerisk/jasmine-fail-hardcore",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Allow Jasmine tests to \"fail-fast\", exiting on the first failure instead of running all tests no matter what. ",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This moves the `fs` stuff out of this module and lets the consumer decide how to persist the fact that a test suite has failed.