### PR TITLE
Better messaging about failure

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@outlinerisk/jasmine-fail-hardcore",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "Allow Jasmine tests to \"fail-fast\", exiting on the first failure instead of running all tests no matter what. ",
   "repository": {
     "type": "git",

--- a/src/index.js
+++ b/src/index.js
@@ -18,13 +18,19 @@ export function init(alreadyFailed = false, onFailure) {
   return {
     specDone(result) {
       if (result.status === 'failed') {
-        shutItDown()
+        console.error(`Spec '${result.description}' failed...`)
+        const expectation = result.failedExpectations[0]
+        if (expectation) {
+          console.error(expectation.stack)
+        }
+        shutItDown(false)
       }
     }
   };
 }
 
-export function shutItDown() {
+export function shutItDown(manual = true) {
+  if (manual) console.error('The application requested we...')
   console.log([
     '| ',
     '| ',
@@ -35,7 +41,7 @@ export function shutItDown() {
     '| 🔥🔥 FAIL FAST 🔥💥',
     '| 🔥🌶🔥',
     '| 🔥',
-    '| 🔥',
+    '| '+(manual ? '🔥👌' : '💥'),
     '| '].join('\n'));
   disableSpecs(refs);
   if (failed || !handleFailure) return

--- a/src/index.js
+++ b/src/index.js
@@ -27,14 +27,16 @@ export function init(alreadyFailed = false, onFailure) {
 export function shutItDown() {
   console.log([
     '| ',
-    '|  🔥     🚀',
-    '| 💥💥💥',
-    '| 🔥🔥 FAIL FAST 🔥💥',
-    '| 💥🌶',
-    '|  🔥',
-    '| 💥',
     '| ',
-    ].join('\n'))
+    '| 💥',
+    '| 🔥     🚀',
+    '| 🔥💥',
+    '| 🔥🔥🔥',
+    '| 🔥🔥 FAIL FAST 🔥💥',
+    '| 🔥🌶🔥',
+    '| 🔥',
+    '| 🔥',
+    '| '].join('\n'));
   disableSpecs(refs);
   if (failed || !handleFailure) return
   failed = true


### PR DESCRIPTION
Should be able to tell what the spec was that failed, and log the error if we have one, this is helpful especially if we are pausing the tests (e.g. to look at the web browser) before the reporter runs.
